### PR TITLE
fix: secrets scans

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,10 +26,7 @@ workflows:
           context:
             - snyk-bot-slack
           channel: runtime-rnd
-          filters:
-            branches:
-              only:
-                - main
+          trusted-branch: main
       - security_scans:
           name: Security Scans
           context:


### PR DESCRIPTION
Secrets scans must run on all branches so it's trigerred during PR checks.